### PR TITLE
Add openJDK 17 to CI pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,30 +4,27 @@ on:
 jobs:
   build-dependencies:
     name: Build Dependencies
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        java: [ 11 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Cache JDK
-        id: cache-jdk17
-        uses: actions/cache@v2
+      - uses: actions/cache@v1
         with:
-          path: ${{ runner.temp }}
-          key: jdk17-${{ hashFiles('java_package.tar.gz') }}
-          restore-keys: jdk17-
-      - run: |
-          download_url="https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_linux-x64_bin.tar.gz"
-          wget -O $RUNNER_TEMP/java_package.tar.gz $download_url
-      - uses: joschi/setup-jdk@v2
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Install JDK {{ matrix.java }}
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
-          distribution: 'jdkfile'
-          java-version: '17'
-          architecture: x64
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-      - run: java --version
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Build Quarkus main
         run: |
           git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly
@@ -41,33 +38,25 @@ jobs:
           path: maven-repo.tgz
   linux-validate-format:
     name: Linux - Validate format
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    needs: build-dependencies
     strategy:
-      fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-    needs: [ build-dependencies ]
+        java: [ 17 ]
     steps:
-      - name: Cache jdk
-        id: jdk17
-        uses: actions/cache@v2
-        with:
-          path: ${{ runner.temp }}
-          key: 'jdk17'
-      - uses: actions/checkout@v2
-      - uses: joschi/setup-jdk@v2
-        with:
-          distribution: 'jdkfile'
-          java-version: '17'
-          architecture: x64
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-      - run: java --version
+      - uses: actions/checkout@v1
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
+      - name: Install JDK {{ matrix.java }}
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -78,30 +67,19 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Maven
         run: |
-          mvn -V -B -s .github/mvn-settings.xml verify -Dvalidate-format -DskipTests -DskipITs
+          mvn -V -B -s .github/mvn-settings.xml verify -Dall-modules -Dvalidate-format -DskipTests -DskipITs
   linux-build-jvm-latest:
     name: PR - Linux - JVM build - Latest Version
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    needs: linux-validate-format
+    env:
+      MODULES_ARG: ${{ needs.detect-test-suite-modules.outputs.MODULES_ARG }}
     strategy:
-      fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-    needs: [ build-dependencies, linux-validate-format ]
+        java: [ 17 ]
     steps:
-      - name: Cache jdk
-        id: jdk17
-        uses: actions/cache@v2
-        with:
-          path: ${{ runner.temp }}
-          key: 'jdk17'
-      - uses: actions/checkout@v2
-      - uses: joschi/setup-jdk@v2
-        with:
-          distribution: 'jdkfile'
-          java-version: '17'
-          architecture: x64
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-      - run: java --version
+      - uses: actions/checkout@v1
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
@@ -110,6 +88,13 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
+      - name: Install JDK {{ matrix.java }}
+        # Uses sha for added security since tags can be updated
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -118,24 +103,14 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - name: Build Quarkus CLI
-        run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
-      - name: Install Quarkus CLI
-        run: |
-          cat <<EOF > ./quarkus-dev-cli
-          #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-          EOF
-          chmod +x ./quarkus-dev-cli
       - name: Build with Maven
-        run: mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+        run: mvn -fae -V -B -s .github/mvn-settings.xml clean verify
       - name: Zip Artifacts
         if: failure()
         run: |
-          zip -R artifacts-latest-linux-jvm17.zip '*-reports/*'
+          zip -R artifacts-latest-linux-jvm${{ matrix.java }}.zip '*-reports/*'
       - uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: ci-artifacts
-          path: artifacts-latest-linux-jvm17.zip
+          path: artifacts-latest-linux-jvm${{ matrix.java }}.zip

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -6,33 +6,30 @@ on:
 jobs:
   build-dependencies:
     name: Build Dependencies
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        java: [ 11 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Cache JDK
-        id: cache-jdk17
-        uses: actions/cache@v2
+      - uses: actions/cache@v1
         with:
-          path: ${{ runner.temp }}
-          key: ${{ runner.os }}-jdk17-${{ hashFiles('java_package.tar.gz') }}
-          restore-keys: ${{ runner.os }}-jdk17-
-      - run: |
-          download_url="https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_linux-x64_bin.tar.gz"
-          wget -O $RUNNER_TEMP/java_package.tar.gz $download_url
-      - uses: joschi/setup-jdk@v2
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Reclaim Disk Space
+        run: .github/ci-prerequisites.sh
+      - name: Install JDK {{ matrix.java }}
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
         with:
-          distribution: 'jdkfile'
-          java-version: '17'
-          architecture: x64
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-      - run: java --version
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Build Quarkus main
         run: |
-            git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B -s .github/mvn-settings.xml clean install -Dquickly
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository
@@ -43,30 +40,31 @@ jobs:
           path: maven-repo.tgz
   linux-build-jvm-latest:
     name: PR - Linux - JVM build - Latest Version
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: linux-validate-format
+    env:
+      MODULES_ARG: ${{ needs.detect-test-suite-modules.outputs.MODULES_ARG }}
     strategy:
-      fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-    needs: [ build-dependencies ]
+        java: [ 17 ]
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache JDK
-        id: cache-jdk17
-        uses: actions/cache@v2
+      - uses: actions/checkout@v1
+      - uses: actions/cache@v1
         with:
-          path: ${{ runner.temp }}
-          key: ${{ runner.os }}-jdk17-${{ hashFiles('java_package.tar.gz') }}
-          restore-keys: ${{ runner.os }}-jdk17-
-      - uses: joschi/setup-jdk@v2
-        with:
-          distribution: 'jdkfile'
-          java-version: '17'
-          architecture: x64
-          jdkFile: ${{ runner.temp }}/java_package.tar.gz
-      - run: java --version
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
+      - name: Install JDK {{ matrix.java }}
+        # Uses sha for added security since tags can be updated
+        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          check-latest: true
       - name: Download Maven Repo
         uses: actions/download-artifact@v1
         with:
@@ -75,24 +73,14 @@ jobs:
       - name: Extract Maven Repo
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - name: Build Quarkus CLI
-        run: |
-          git clone https://github.com/quarkusio/quarkus.git && cd quarkus/devtools/cli && mvn -B -s ../../../.github/mvn-settings.xml clean install -Dquickly
-      - name: Install Quarkus CLI
-        run: |
-          cat <<EOF > ./quarkus-dev-cli
-          #!/bin/bash
-          java -jar $PWD/quarkus/devtools/cli/target/quarkus-cli-999-SNAPSHOT-runner.jar "\$@"
-          EOF
-          chmod +x ./quarkus-dev-cli
       - name: Build with Maven
-        run: mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dinclude.quarkus-cli-tests -Dts.quarkus.cli.cmd="${PWD}/quarkus-dev-cli"
+        run: mvn -fae -V -B -s .github/mvn-settings.xml clean verify
       - name: Zip Artifacts
         if: failure()
         run: |
-          zip -R artifacts-latest-linux-jvm17.zip '*-reports/*'
+          zip -R artifacts-latest-linux-jvm${{ matrix.java }}.zip '*-reports/*'
       - uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: ci-artifacts
-          path: artifacts-latest-linux-jvm17.zip
+          path: artifacts-latest-linux-jvm${{ matrix.java }}.zip


### PR DESCRIPTION
OpenJDK 17 was released. This PR update CI jobs in order to use this release