### PR TITLE
Remove redundant maven dependency

### DIFF
--- a/jdk17/jaxrs-panache/pom.xml
+++ b/jdk17/jaxrs-panache/pom.xml
@@ -21,10 +21,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-graphql</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
JDK 17 / Quarkus 999-SNAPSHOT
Works with Quarkus 2.8.3.Final and with an older version(7 days ago) of Quarkus upstream

Looks like, the unused `quarkus-smallrye-graphql` extension is breaking the following scenario:

-  `io.quarkus.ts.jdk17.resources.FruitsResourceIT#listFruitTest`

Stacktrace
```
16:11:43,967 INFO  [app] 16:11:42,936 HTTP Request to /fruits failed, error id: 47c7fa9e-ab25-4f7c-89b3-30ccda5106b9-1: javax.validation.ValidationException: HV000149: An exception occurred during message interpolation
16:11:43,968 INFO  [app]        at org.hibernate.validator.internal.engine.validationcontext.AbstractValidationContext.interpolate(AbstractValidationContext.java:331)
16:11:43,969 INFO  [app]        at org.hibernate.validator.internal.engine.validationcontext.AbstractValidationContext.addConstraintFailure(AbstractValidationContext.java:231)
16:11:43,969 INFO  [app]        at org.hibernate.validator.internal.engine.validationcontext.ParameterExecutableValidationContext.addConstraintFailure(ParameterExecutableValidationContext.java:38)
16:11:43,970 INFO  [app]        at org.hibernate.validator.internal.engine.constraintvalidation.ConstraintTree.validateConstraints(ConstraintTree.java:79)
16:11:43,971 INFO  [app]        at org.hibernate.validator.internal.metadata.core.MetaConstraint.doValidateConstraint(MetaConstraint.java:130)
16:11:43,971 INFO  [app]        at org.hibernate.validator.internal.metadata.core.MetaConstraint.validateConstraint(MetaConstraint.java:123)
16:11:43,972 INFO  [app]        at org.hibernate.validator.internal.engine.ValidatorImpl.validateMetaConstraint(ValidatorImpl.java:555)
16:11:43,972 INFO  [app]        at org.hibernate.validator.internal.engine.ValidatorImpl.validateConstraintsForSingleDefaultGroupElement(ValidatorImpl.java:518)
16:11:43,973 INFO  [app]        at org.hibernate.validator.internal.engine.ValidatorImpl.validateConstraintsForDefaultGroup(ValidatorImpl.java:488)
16:11:43,973 INFO  [app]        at org.hibernate.validator.internal.engine.ValidatorImpl.validateConstraintsForCurrentGroup(ValidatorImpl.java:450)
16:11:43,974 INFO  [app]        at org.hibernate.validator.internal.engine.ValidatorImpl.validateInContext(ValidatorImpl.java:400)
16:11:43,974 INFO  [app]        at org.hibernate.validator.internal.engine.ValidatorImpl.validateCascadedAnnotatedObjectForCurrentGroup(ValidatorImpl.java:629)
16:11:43,975 INFO  [app]        at org.hibernate.validator.internal.engine.ValidatorImpl.validateCascadedConstraints(ValidatorImpl.java:590)
16:11:43,975 INFO  [app]        at org.hibernate.validator.internal.engine.ValidatorImpl.validateParametersInContext(ValidatorImpl.java:880)
16:11:43,976 INFO  [app]        at org.hibernate.validator.internal.engine.ValidatorImpl.validateParameters(ValidatorImpl.java:283)
16:11:43,976 INFO  [app]        at org.hibernate.validator.internal.engine.ValidatorImpl.validateParameters(ValidatorImpl.java:235)
16:11:43,977 INFO  [app]        at io.quarkus.hibernate.validator.runtime.interceptor.AbstractMethodValidationInterceptor.validateMethodInvocation(AbstractMethodValidationInterceptor.java:60)
16:11:43,978 INFO  [app]        at io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor.validateMethodInvocation(JaxrsEndPointValidationInterceptor.java:35)
16:11:43,978 INFO  [app]        at io.quarkus.hibernate.validator.runtime.jaxrs.JaxrsEndPointValidationInterceptor_Bean.intercept(Unknown Source)
16:11:43,979 INFO  [app]        at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)
16:11:43,979 INFO  [app]        at io.quarkus.arc.impl.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:50)
16:11:43,980 INFO  [app]        at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase.invokeInOurTx(TransactionalInterceptorBase.java:133)
16:11:43,980 INFO  [app]        at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase.invokeInOurTx(TransactionalInterceptorBase.java:104)
16:11:43,981 INFO  [app]        at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired.doIntercept(TransactionalInterceptorRequired.java:38)
16:11:43,981 INFO  [app]        at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorBase.intercept(TransactionalInterceptorBase.java:58)
16:11:43,981 INFO  [app]        at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired.intercept(TransactionalInterceptorRequired.java:32)
16:11:43,982 INFO  [app]        at io.quarkus.narayana.jta.runtime.interceptor.TransactionalInterceptorRequired_Bean.intercept(Unknown Source)
16:11:43,982 INFO  [app]        at io.quarkus.arc.impl.InterceptorInvocation.invoke(InterceptorInvocation.java:41)
16:11:43,982 INFO  [app]        at io.quarkus.arc.impl.AroundInvokeInvocationContext.perform(AroundInvokeInvocationContext.java:41)
16:11:43,983 INFO  [app]        at io.quarkus.arc.impl.InvocationContexts.performAroundInvoke(InvocationContexts.java:32)
16:11:43,983 INFO  [app]        at io.quarkus.ts.jdk17.resources.FruitsResource_Subclass.add(Unknown Source)
16:11:43,983 INFO  [app]        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
16:11:43,984 INFO  [app]        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
16:11:43,984 INFO  [app]        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
16:11:43,984 INFO  [app]        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
16:11:43,985 INFO  [app]        at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:170)
16:11:43,985 INFO  [app]        at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:130)
16:11:43,985 INFO  [app]        at org.jboss.resteasy.core.ResourceMethodInvoker.internalInvokeOnTarget(ResourceMethodInvoker.java:660)
16:11:43,985 INFO  [app]        at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTargetAfterFilter(ResourceMethodInvoker.java:524)
16:11:43,986 INFO  [app]        at org.jboss.resteasy.core.ResourceMethodInvoker.lambda$invokeOnTarget$2(ResourceMethodInvoker.java:474)
16:11:43,986 INFO  [app]        at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:364)
16:11:43,986 INFO  [app]        at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:476)
16:11:43,987 INFO  [app]        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:434)
16:11:43,987 INFO  [app]        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:408)
16:11:43,987 INFO  [app]        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:69)
16:11:43,988 INFO  [app]        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:492)
16:11:43,988 INFO  [app]        at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:261)
16:11:43,988 INFO  [app]        at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:161)
16:11:43,988 INFO  [app]        at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:364)
16:11:43,989 INFO  [app]        at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:164)
16:11:43,989 INFO  [app]        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:247)
16:11:43,989 INFO  [app]        at io.quarkus.resteasy.runtime.standalone.RequestDispatcher.service(RequestDispatcher.java:73)
16:11:43,989 INFO  [app]        at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatch(VertxRequestHandler.java:151)
16:11:43,990 INFO  [app]        at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler$1.run(VertxRequestHandler.java:91)
16:11:43,990 INFO  [app]        at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:548)
16:11:43,990 INFO  [app]        at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2449)
16:11:43,991 INFO  [app]        at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1478)
16:11:43,991 INFO  [app]        at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
16:11:43,991 INFO  [app]        at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
16:11:43,991 INFO  [app]        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
16:11:43,991 INFO  [app]        at java.base/java.lang.Thread.run(Thread.java:833)
16:11:43,992 INFO  [app] Caused by: java.lang.NullPointerException: Cannot invoke "io.smallrye.graphql.execution.context.SmallRyeContext.unwrap(java.lang.Class)" because "smallRyeContext" is null
16:11:43,992 INFO  [app]        at io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLLocaleResolver.getHeaders(SmallRyeGraphQLLocaleResolver.java:53)
16:11:43,992 INFO  [app]        at io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLLocaleResolver.getAcceptableLanguages(SmallRyeGraphQLLocaleResolver.java:40)
16:11:43,992 INFO  [app]        at io.quarkus.smallrye.graphql.runtime.SmallRyeGraphQLLocaleResolver.resolve(SmallRyeGraphQLLocaleResolver.java:27)
16:11:43,993 INFO  [app]        at io.quarkus.hibernate.validator.runtime.locale.LocaleResolversWrapper.resolve(LocaleResolversWrapper.java:27)
16:11:43,993 INFO  [app]        at org.hibernate.validator.messageinterpolation.AbstractMessageInterpolator.interpolate(AbstractMessageInterpolator.java:343)
16:11:43,993 INFO  [app]        at org.hibernate.validator.internal.engine.validationcontext.AbstractValidationContext.interpolate(AbstractValidationContext.java:322)
16:11:43,993 INFO  [app]        ... 60 more

```