### PR TITLE
Update native image builders - use version 22.2

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         java: [ 17 ]
-        image: [ "ubi-quarkus-mandrel:21.3-java17" ]
+        image: [ "ubi-quarkus-mandrel:22.2-java17" ]
         profiles: [ "JDK17"]
     steps:
       - uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
                 <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>4g</quarkus.native.native-image-xmx>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3-java17</quarkus.native.builder-image>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.2-java17</quarkus.native.builder-image>
                 <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
             </properties>
         </profile>


### PR DESCRIPTION
Updates GraalVM/Mandrel version to 22.2.