### PR TITLE
Migrate from javax to jakarta

### DIFF
--- a/jdk17/graphql/src/test/java/io/quarkus/ts/http/graphql/Utils.java
+++ b/jdk17/graphql/src/test/java/io/quarkus/ts/http/graphql/Utils.java
@@ -2,7 +2,7 @@ package io.quarkus.ts.http.graphql;
 
 import static io.restassured.RestAssured.given;
 
-import javax.json.Json;
+import jakarta.json.Json;
 
 import io.restassured.response.Response;
 

--- a/jdk17/jaxrs-panache/src/main/java/io/quarkus/ts/jdk17/model/Fruit.java
+++ b/jdk17/jaxrs-panache/src/main/java/io/quarkus/ts/jdk17/model/Fruit.java
@@ -3,10 +3,10 @@ package io.quarkus.ts.jdk17.model;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.persistence.LockModeType;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
-import javax.ws.rs.NotFoundException;
+import jakarta.persistence.LockModeType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import jakarta.ws.rs.NotFoundException;
 
 import io.quarkus.ts.jdk17.storage.FruitEntity;
 

--- a/jdk17/jaxrs-panache/src/main/java/io/quarkus/ts/jdk17/resources/FruitsResource.java
+++ b/jdk17/jaxrs-panache/src/main/java/io/quarkus/ts/jdk17/resources/FruitsResource.java
@@ -1,20 +1,20 @@
 package io.quarkus.ts.jdk17.resources;
 
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 
 import java.util.List;
 
-import javax.transaction.Transactional;
-import javax.validation.Valid;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.WebApplicationException;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.WebApplicationException;
 
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.quarkus.ts.jdk17.model.Fruit;

--- a/jdk17/jaxrs-panache/src/main/java/io/quarkus/ts/jdk17/storage/FruitEntity.java
+++ b/jdk17/jaxrs-panache/src/main/java/io/quarkus/ts/jdk17/storage/FruitEntity.java
@@ -1,9 +1,9 @@
 package io.quarkus.ts.jdk17.storage;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.NamedQuery;
-import javax.persistence.QueryHint;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.QueryHint;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 

--- a/jdk17/jaxrs-panache/src/test/java/io/quarkus/ts/jdk17/resources/FruitsResourceIT.java
+++ b/jdk17/jaxrs-panache/src/test/java/io/quarkus/ts/jdk17/resources/FruitsResourceIT.java
@@ -7,7 +7,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
With https://github.com/quarkusio/quarkus/pull/30856 `javax` imports need to be replaced with `jakarta` ones.