### PR TITLE
Migrate to Hibernate 6 - use dedicated table sequence and fix max query

### DIFF
--- a/jdk17/jaxrs-panache/src/main/java/io/quarkus/ts/jdk17/storage/FruitEntity.java
+++ b/jdk17/jaxrs-panache/src/main/java/io/quarkus/ts/jdk17/storage/FruitEntity.java
@@ -22,7 +22,9 @@ public class FruitEntity extends PanacheEntity {
         return FruitEntity.getEntityManager().createQuery("""
                       SELECT f
                       FROM fruit f
-                      WHERE char_length(f.description) = (SELECT max(char_length(description)) FROM fruit )
-                """, FruitEntity.class).getSingleResult();
+                      ORDER BY char_length(f.description) DESC
+                """, FruitEntity.class)
+                .setMaxResults(1)
+                .getSingleResult();
     }
 }

--- a/jdk17/jaxrs-panache/src/main/resources/import.sql
+++ b/jdk17/jaxrs-panache/src/main/resources/import.sql
@@ -1,2 +1,2 @@
-INSERT INTO fruit (id, name, description) VALUES (nextval('hibernate_sequence'), 'Apple', 'Winter fruit');
-INSERT INTO fruit (id, name, description) VALUES (nextval('hibernate_sequence'), 'Pineapple', 'Tropical fruit');
+INSERT INTO fruit (id, name, description) VALUES (nextval('Fruit_SEQ'), 'Apple', 'Winter fruit');
+INSERT INTO fruit (id, name, description) VALUES (nextval('Fruit_SEQ'), 'Pineapple', 'Tropical fruit');


### PR DESCRIPTION
- We need to use table sequence instead of Hibernate one
- Finding of item with maximum description failed as right side is treated as object now (not comparable with description length). I think my way is more efficient anyway