### PR TITLE
Switch to OpenTelemetry as upstream dropped OpenTracing support in GraphQL

### DIFF
--- a/jdk17/graphql/pom.xml
+++ b/jdk17/graphql/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-opentracing</artifactId>
+            <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus.qe</groupId>

--- a/jdk17/graphql/src/main/resources/application.properties
+++ b/jdk17/graphql/src/main/resources/application.properties
@@ -1,8 +1,2 @@
 smallrye.graphql.allowGet=true
-
 quarkus.application.name=graphql
-
-quarkus.jaeger.service-name=graphql-service
-quarkus.jaeger.sampler-type=const
-quarkus.jaeger.sampler-param=1
-quarkus.jaeger.endpoint=http://localhost:14268/api/traces

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
-        <quarkus.qe.framework.version>1.2.3.Final</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.3.0.Beta16</quarkus.qe.framework.version>
         <formatter-maven-plugin.version>2.22.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.6.2</impsort-maven-plugin.version>
         <xml-format-maven-plugin.version>3.2.2</xml-format-maven-plugin.version>


### PR DESCRIPTION
Switch to OpenTelemetry as upstream dropped OpenTracing support in GraphQL

Fixes daily runs.