### PR TITLE
Install pigz, which is required by some of actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
+      - name: Install required tools
+        run: |
+          sudo apt update && sudo apt install pigz
       - name: Install JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
See a failure[1] in our daily CI  for details

[1] https://github.com/quarkus-qe/quarkus-jdkspecifics/actions/runs/5968442476/job/16204024073

