### PR TITLE
Jdk 21 news scenario for some JEPs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 17, 21-ea ]
     steps:
       - uses: actions/checkout@v3
       - name: Reclaim Disk Space
@@ -73,7 +73,7 @@ jobs:
         run: |
           mvn -V -B -s .github/mvn-settings.xml verify -Dvalidate-format -DskipTests -DskipITs
       - name: Build with Maven
-        run: mvn -fae -V -B -s .github/mvn-settings.xml clean verify
+        run: mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dnet.bytebuddy.experimental=true
       - name: Zip Artifacts
         if: failure()
         run: |

--- a/README.md
+++ b/README.md
@@ -53,3 +53,9 @@ Interesting preview:
 
 ### GraphQL
 * [Records](https://openjdk.java.net/jeps/395)
+
+### resteasy-reactive-jackson
+* [Record Patterns](https://openjdk.java.net/jeps/440)
+* [Pattern Matching for switch](https://openjdk.java.net/jeps/441)
+* [Sequenced Collections](https://openjdk.java.net/jeps/431)
+* [Code Snippets in Java API Documentation](https://openjdk.java.net/jeps/413)

--- a/jdk17/graphql/pom.xml
+++ b/jdk17/graphql/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.quarkus.ts.jdk17</groupId>
+        <groupId>io.quarkus.ts.jdk.specific</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>

--- a/jdk17/jakarta-rest-panache/pom.xml
+++ b/jdk17/jakarta-rest-panache/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.quarkus.ts.jdk17</groupId>
+        <groupId>io.quarkus.ts.jdk.specific</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>

--- a/jdk17/jakarta-rest-panache/src/test/java/io/quarkus/ts/jdk17/resources/FruitsResourceIT.java
+++ b/jdk17/jakarta-rest-panache/src/test/java/io/quarkus/ts/jdk17/resources/FruitsResourceIT.java
@@ -24,7 +24,7 @@ import io.vertx.core.json.JsonObject;
 @QuarkusScenario
 public class FruitsResourceIT {
 
-    @Container(image = "${postgresql.13.image}", port = 5432, expectedLog = "listening on IPv4 address")
+    @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address")
     static PostgresqlService postgres = new PostgresqlService();
 
     @QuarkusApplication

--- a/jdk21/resteasy-reactive-jackson/pom.xml
+++ b/jdk21/resteasy-reactive-jackson/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.jdk.specific</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>resteasy-reactive-jackson</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus JDK21 TS: test</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-postgresql</artifactId>
+        </dependency>
+        <!-- Testing -->
+        <dependency>
+            <groupId>io.quarkus.qe</groupId>
+            <artifactId>quarkus-test-service-database</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/characters/Character.java
+++ b/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/characters/Character.java
@@ -1,0 +1,74 @@
+package io.quarkus.ts.jdk21.characters;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.QueryHint;
+import jakarta.persistence.SequenceGenerator;
+
+@Entity(name = "characters")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "affiliation", discriminatorType = DiscriminatorType.STRING)
+@NamedQuery(name = "Character.findAll", query = """
+        SELECT c FROM characters c ORDER BY c.id
+        """, hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
+public class Character implements Comparable<Character> {
+
+    @Id
+    @SequenceGenerator(name = "characterSequence", sequenceName = "character_id_seq", allocationSize = 1, initialValue = 5)
+    @GeneratedValue(generator = "characterSequence")
+    private Integer id;
+
+    @Column(length = 40, nullable = false)
+    private String name;
+
+    @Column(length = 40)
+    private String quirk;
+
+    public Character() {
+    }
+
+    public Character(String name) {
+        this.name = name;
+    }
+
+    public Character(String name, String quirk) {
+        this.name = name;
+        this.quirk = quirk;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getQuirk() {
+        return quirk;
+    }
+
+    public void setQuirk(String quirk) {
+        this.quirk = quirk;
+    }
+
+    @Override
+    public int compareTo(Character character) {
+        return id.compareTo(character.id);
+    }
+}

--- a/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/characters/CharacterResource.java
+++ b/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/characters/CharacterResource.java
@@ -1,0 +1,110 @@
+package io.quarkus.ts.jdk21.characters;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+import java.util.List;
+
+@Path("characters")
+@ApplicationScoped
+public class CharacterResource {
+    @Inject
+    EntityManager entityManager;
+
+    @GET
+    public List<Character> get() {
+        return entityManager.createNamedQuery("Character.findAll", Character.class).getResultList();
+    }
+
+    /**
+     * Showcasing the enhancement switch as it can detect null, so no if statement before the switch statement.
+     * Also this showcase that now switch statement can select by class/data type.
+     * <p>
+     * Prior to JDK 21 it would be
+     * {@snippet :
+     *     Character entity = entityManager.find(Character.class, id);
+     *     if(entity == null) {
+     *          // do something
+     *     }
+     *     switch (entity) {
+     *          // switch cases
+     *     }
+     * }
+     * @param id Id of hero
+     * @return Error or type of character
+     */
+    @GET
+    @Path("{id}")
+    public Response whoIsThey(Integer id) {
+        Character entity = entityManager.find(Character.class, id);
+        switch (entity) {
+            case null -> throw new WebApplicationException("Character with id of " + id + " is unknown.", 404);
+            case Hero h -> {
+                return Response.ok(h.getName() + " is hero with rank " + h.getHeroRank()).status(200).build();
+            }
+            case Villain v -> {
+                return Response.ok(v.getName() + " is villain with bounty " + v.getBounty()).status(200).build();
+            }
+            default -> throw new IllegalStateException("Unexpected value: " + entity);
+        }
+    }
+
+    /**
+     * This method showcase the usage os when statement in switch.
+     * When is replacement for if in switch statement. The if can be still used but inside the case scope.
+     * This show two different work logic using switch with enum. Both have same result but when using when the code readability
+     * with this simple example is worse.
+     *
+     * @param rankString Which rank can be described
+     * @return Description of the rank if rank exist otherwise return error string
+     */
+    @GET
+    @Path("rank/{rankValue}")
+    public Response heroRankExplanation(@PathParam("rankValue") String rankString) {
+        Hero.Rank rank;
+        try {
+            rank = Hero.Rank.valueOf(rankString);
+        } catch (IllegalArgumentException e) {
+            throw new WebApplicationException("Can't get any information about this rank.", 404);
+        }
+        switch (rank) {
+            case Hero.Rank r when r == Hero.Rank.S -> {
+                return Response.ok("S rank is highest rank which can hero achieve. Only few have achieve this.").status(200).build();
+            }
+            case Hero.Rank r when r == Hero.Rank.A -> {
+                return Response.ok("A rank is for experience heroes which had done good work.").status(200).build();
+            }
+            case Hero.Rank.B -> {
+                return Response.ok("B rank is for new heroes which have done few jobs.").status(200).build();
+            }
+            case Hero.Rank.F -> {
+                return Response.ok("F rank is inexperience heroes which have started.").status(200).build();
+            }
+            default -> throw new IllegalStateException("This should never happen.");
+        }
+    }
+
+    @POST
+    @Transactional
+    @Path("hero")
+    public Response createHero(Hero hero) {
+        entityManager.persist(hero);
+        return Response.ok(hero).status(201).build();
+    }
+
+    @POST
+    @Transactional
+    @Path("villain")
+    public Response createVillain(Villain villain) {
+        entityManager.persist(villain);
+        return Response.ok(villain).status(201).build();
+    }
+}

--- a/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/characters/Hero.java
+++ b/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/characters/Hero.java
@@ -1,0 +1,50 @@
+package io.quarkus.ts.jdk21.characters;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+
+import static jakarta.persistence.EnumType.STRING;
+
+@Entity
+@DiscriminatorValue("hero")
+public class Hero extends Character {
+
+    public enum Rank {
+        S,
+        A,
+        B,
+        F;
+    }
+
+    @Enumerated(STRING)
+    private Rank heroRank;
+
+    public Hero() {
+        super();
+        this.heroRank = Rank.F;
+    }
+
+    public Hero(Rank heroRank) {
+        super();
+        this.heroRank = heroRank;
+    }
+
+    public Hero(String name, Rank heroRank) {
+        super(name);
+        this.heroRank = heroRank;
+    }
+
+    public Hero(String name, String quirk, Rank heroRank) {
+        super(name, quirk);
+        this.heroRank = heroRank;
+    }
+
+    public Rank getHeroRank() {
+        return heroRank;
+    }
+
+    public void setHeroRank(Rank heroRank) {
+        this.heroRank = heroRank;
+    }
+}

--- a/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/characters/Villain.java
+++ b/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/characters/Villain.java
@@ -1,0 +1,28 @@
+package io.quarkus.ts.jdk21.characters;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("villain")
+public class Villain extends Character {
+
+    private long bounty;
+
+    public Villain() {
+        super();
+    }
+
+    public Villain(String name, long bounty) {
+        super(name);
+        this.bounty = bounty;
+    }
+
+    public long getBounty() {
+        return bounty;
+    }
+
+    public void setBounty(long bounty) {
+        this.bounty = bounty;
+    }
+}

--- a/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/jep431/SequencedCollectionShowcase.java
+++ b/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/jep431/SequencedCollectionShowcase.java
@@ -1,0 +1,49 @@
+package io.quarkus.ts.jdk21.jep431;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.QueryHint;
+import jakarta.persistence.SequenceGenerator;
+
+import java.util.SequencedCollection;
+
+@Entity(name = "jep431")
+@NamedQuery(name = "SequencedCollectionShowcase.findAll", query = """
+        SELECT c FROM jep431 c ORDER BY c.id
+        """, hints = @QueryHint(name = "org.hibernate.cacheable", value = "true"))
+public class SequencedCollectionShowcase {
+
+    @Id
+    @SequenceGenerator(name = "jep431Sequence", sequenceName = "jep431_id_seq", allocationSize = 1, initialValue = 5)
+    @GeneratedValue(generator = "jep431Sequence")
+    private Integer id;
+
+    @ElementCollection
+    private SequencedCollection<String> sequencedCollection;
+
+    public SequencedCollectionShowcase() {
+    }
+
+    public SequencedCollectionShowcase(SequencedCollection<String> sequencedCollection) {
+        this.sequencedCollection = sequencedCollection;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public SequencedCollection<String> getSequencedCollection() {
+        return sequencedCollection;
+    }
+
+    public void setSequencedCollection(SequencedCollection<String> sequencedCollection) {
+        this.sequencedCollection = sequencedCollection;
+    }
+}

--- a/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/jep431/SequencedCollectionShowcaseResource.java
+++ b/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/jep431/SequencedCollectionShowcaseResource.java
@@ -1,0 +1,54 @@
+package io.quarkus.ts.jdk21.jep431;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+import java.util.List;
+
+@Path("jep431")
+public class SequencedCollectionShowcaseResource {
+    @Inject
+    EntityManager entityManager;
+
+    @GET
+    public List<SequencedCollectionShowcaseResource> get() {
+        return entityManager
+                .createNamedQuery("SequencedCollectionShowcase.findAll", SequencedCollectionShowcaseResource.class)
+                .getResultList();
+    }
+
+    @GET
+    @Transactional
+    @Path("reverse")
+    public Response getReversed() {
+        SequencedCollectionShowcase entity = entityManager.find(SequencedCollectionShowcase.class, 1);
+        entity.setSequencedCollection(entity.getSequencedCollection().reversed());
+        entityManager.persist(entity);
+        return Response.ok("Reversed").status(200).build();
+    }
+
+    @POST
+    @Transactional
+    @Path("first")
+    public Response addToStartOfCollection(String string) {
+        SequencedCollectionShowcase entity = entityManager.find(SequencedCollectionShowcase.class, 1);
+        entity.getSequencedCollection().addFirst(string);
+        entityManager.persist(entity);
+        return Response.ok("Added first").status(201).build();
+    }
+
+    @POST
+    @Transactional
+    @Path("last")
+    public Response addToEndOfCollection(String string) {
+        SequencedCollectionShowcase entity = entityManager.find(SequencedCollectionShowcase.class, 1);
+        entity.getSequencedCollection().addLast(string);
+        entityManager.persist(entity);
+        return Response.ok("Added last").status(201).build();
+    }
+}

--- a/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/jep440/Jep440Resources.java
+++ b/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/jep440/Jep440Resources.java
@@ -1,0 +1,40 @@
+package io.quarkus.ts.jdk21.jep440;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("jep440")
+@ApplicationScoped
+public class Jep440Resources {
+
+    /**
+     * As JEP 440 introduce records patterns it can make possible to check if record contains specific data types.
+     * This can be used for example if record is used as abstract data carrier. This is shown in this method as it only
+     * accept the record object containing String and Integer or String and String.
+     * <p>
+     * For example, we can expect the that client sent request with 2 parameter but client send request with only one parameter
+     * so record is created as <Object, null>. Before JEP 440 there was need to manually check if second attribute was null,
+     * now we can easily check if the request contains types which are expected.
+     *
+     * @param recordShowcase Data of posts request
+     * @return Response containing string with details of record attributes or unsupported string mention
+     */
+    @POST
+    public Response jep440(RecordShowcase recordShowcase) {
+        switch (recordShowcase) {
+            case RecordShowcase(String string, Integer integer) -> {
+                return Response.ok("This show case record containing string " + string + " and integer " + integer).status(200)
+                        .build();
+            }
+            case RecordShowcase(String string1, String string2) -> {
+                return Response.ok("This show case record containing string " + string1 + " and string " + string2).status(200)
+                        .build();
+            }
+            default -> {
+                return Response.ok("Unsupported type of record input").status(200).build();
+            }
+        }
+    }
+}

--- a/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/jep440/RecordShowcase.java
+++ b/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/jep440/RecordShowcase.java
@@ -1,0 +1,4 @@
+package io.quarkus.ts.jdk21.jep440;
+
+public record RecordShowcase(Object value1, Object value2) {
+}

--- a/jdk21/resteasy-reactive-jackson/src/main/resources/application.properties
+++ b/jdk21/resteasy-reactive-jackson/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+quarkus.datasource.db-kind=postgresql
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.log.sql=true
+quarkus.hibernate-orm.sql-load-script=import.sql

--- a/jdk21/resteasy-reactive-jackson/src/main/resources/import.sql
+++ b/jdk21/resteasy-reactive-jackson/src/main/resources/import.sql
@@ -1,0 +1,9 @@
+-- Insert 2 heroes
+INSERT INTO characters(id, affiliation, name, heroRank) VALUES (1, 'hero', 'Quarkus Girl', 'S');
+INSERT INTO characters(id, affiliation, name, heroRank, quirk) VALUES (2, 'hero', 'Captain Quarkus', 'A', 'Super shield');
+-- Insert 2 villains
+INSERT INTO characters(id, affiliation, name, bounty, quirk) VALUES (3, 'villain', 'Professor Trick', 150000, 'Body scatter');
+INSERT INTO characters(id, affiliation, name, bounty) VALUES (4, 'villain', 'Doctor Quarkus', 5000000);
+
+-- Used for testing
+insert INTO jep431(id) VALUES (1);

--- a/jdk21/resteasy-reactive-jackson/src/test/java/io/quarkus/ts/jdk21/characters/CharacterResourceIT.java
+++ b/jdk21/resteasy-reactive-jackson/src/test/java/io/quarkus/ts/jdk21/characters/CharacterResourceIT.java
@@ -1,0 +1,127 @@
+package io.quarkus.ts.jdk21.characters;
+
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+import io.vertx.core.json.JsonObject;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.text.IsEmptyString.emptyString;
+import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
+
+@QuarkusScenario
+public class CharacterResourceIT {
+    @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address")
+    static PostgresqlService postgres = new PostgresqlService();
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", postgres.getUser())
+            .withProperty("quarkus.datasource.password", postgres.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", postgres::getJdbcUrl)
+            .withProperty("quarkus.datasource.reactive.url", postgres::getReactiveUrl);
+
+    @Test
+    public void testAllCharacters() {
+        given()
+                .when()
+                .get("characters")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(stringContainsInOrder("\"id\":1", "\"id\":2", "\"id\":3", "\"id\":4"));
+    }
+
+    @Test
+    public void testCharacterNotFound() {
+        given()
+                .when()
+                .get("characters/3939")
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body(emptyString());
+    }
+
+    @Test
+    public void testCharacterIsHero() {
+        given()
+                .when()
+                .get("characters/1")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("is hero with rank"));
+    }
+
+    @Test
+    public void testCharacterIsVillain() {
+        given()
+                .when()
+                .get("characters/3")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("is villain with bounty"));
+    }
+
+    @Test
+    public void testRankDescription() {
+        given()
+                .when()
+                .get("characters/rank/F")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("rank is"));
+    }
+
+    @Test
+    public void testRankDescriptionNotFound() {
+        given()
+                .when()
+                .get("characters/rank/Q")
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body(emptyString());
+    }
+
+    @Test
+    public void testAddHeroAndCheckIfExist() {
+        Hero addedHero = given()
+                .body(JsonObject.mapFrom(new Hero("Hero", Hero.Rank.F)).encode())
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("characters/hero")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .extract().body().as(Hero.class);
+
+        given()
+                .when()
+                .get("characters/" + addedHero.getId())
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("is hero with rank"));
+    }
+
+    @Test
+    public void testAddVillainAndCheckIfExist() {
+        Villain addedVillain = given()
+                .body(JsonObject.mapFrom(new Villain("Villain", 300000)).encode())
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("characters/villain")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .extract().body().as(Villain.class);
+
+        given()
+                .when()
+                .get("characters/" + addedVillain.getId())
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("is villain with bounty"));
+    }
+}

--- a/jdk21/resteasy-reactive-jackson/src/test/java/io/quarkus/ts/jdk21/jep431/SequencedCollectionShowcaseResourceIT.java
+++ b/jdk21/resteasy-reactive-jackson/src/test/java/io/quarkus/ts/jdk21/jep431/SequencedCollectionShowcaseResourceIT.java
@@ -1,0 +1,111 @@
+package io.quarkus.ts.jdk21.jep431;
+
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.jdk21.jep440.RecordShowcase;
+import io.vertx.core.json.JsonObject;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Request;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
+
+@QuarkusScenario
+public class SequencedCollectionShowcaseResourceIT {
+    public static final String stringToTest1 = "String1";
+    public static final String stringToTest2 = "String2";
+    @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address")
+    static PostgresqlService postgres = new PostgresqlService();
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", postgres.getUser())
+            .withProperty("quarkus.datasource.password", postgres.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", postgres::getJdbcUrl)
+            .withProperty("quarkus.datasource.reactive.url", postgres::getReactiveUrl);
+
+    @BeforeEach
+    public void prepare() {
+        given()
+                .body(stringToTest1)
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("jep431/first")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(containsString("Added first"));
+
+        given()
+                .body(stringToTest2)
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("jep431/first")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(containsString("Added first"));
+    }
+
+    @Test
+    public void testAddToCollection() {
+        String stringToTest3 = "String3";
+        String stringToTest4 = "String4";
+
+        given()
+                .body(stringToTest3)
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("jep431/last")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(containsString("Added last"));
+
+        given()
+                .body(stringToTest4)
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("jep431/first")
+                .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .body(containsString("Added first"));
+
+        given()
+                .when()
+                .get("jep431")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(stringContainsInOrder(stringToTest4, stringToTest2, stringToTest1, stringToTest3));
+    }
+
+    @Test
+    public void testReversedCollection() {
+        given()
+                .when()
+                .get("jep431")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(stringContainsInOrder(stringToTest1, stringToTest2));
+
+        given()
+                .when()
+                .get("jep431/reverse")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("Reversed"));
+
+        given()
+                .when()
+                .get("jep431")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(stringContainsInOrder(stringToTest2, stringToTest1));
+    }
+}

--- a/jdk21/resteasy-reactive-jackson/src/test/java/io/quarkus/ts/jdk21/jep440/Jep440ResourceIT.java
+++ b/jdk21/resteasy-reactive-jackson/src/test/java/io/quarkus/ts/jdk21/jep440/Jep440ResourceIT.java
@@ -1,0 +1,88 @@
+package io.quarkus.ts.jdk21.jep440;
+
+import io.quarkus.test.bootstrap.PostgresqlService;
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.Container;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.jdk21.characters.Hero;
+import io.quarkus.ts.jdk21.characters.Villain;
+import io.vertx.core.json.JsonObject;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.text.IsEmptyString.emptyString;
+import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
+
+@QuarkusScenario
+public class Jep440ResourceIT {
+    @Container(image = "${postgresql.latest.image}", port = 5432, expectedLog = "listening on IPv4 address")
+    static PostgresqlService postgres = new PostgresqlService();
+
+    @QuarkusApplication
+    static final RestService app = new RestService()
+            .withProperty("quarkus.datasource.username", postgres.getUser())
+            .withProperty("quarkus.datasource.password", postgres.getPassword())
+            .withProperty("quarkus.datasource.jdbc.url", postgres::getJdbcUrl)
+            .withProperty("quarkus.datasource.reactive.url", postgres::getReactiveUrl);
+
+    @Test
+    public void testJep440Success1() {
+        String stringToTest = "String";
+        int intToTest = 39;
+        given()
+                .body(JsonObject.mapFrom(new RecordShowcase(stringToTest, intToTest)).encode())
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("jep440")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("This show case record containing string "
+                        + stringToTest + " and integer " + intToTest));
+    }
+
+    @Test
+    public void testJep440Success2() {
+        String stringToTest = "String";
+        given()
+                .body(JsonObject.mapFrom(new RecordShowcase(stringToTest, stringToTest)).encode())
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("jep440")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("This show case record containing string "
+                        + stringToTest + " and string " + stringToTest));
+    }
+
+    @Test
+    public void testJep440Negative() {
+        int intToTest = 39;
+        given()
+                .body(JsonObject.mapFrom(new RecordShowcase(intToTest, intToTest))
+                        .encode())
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("jep440")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("Unsupported type of record input"));
+    }
+
+    @Test
+    public void testJep440NegativeWithNull() {
+        int intToTest = 39;
+        given()
+                .body(JsonObject.mapFrom(new RecordShowcase(intToTest, null))
+                        .encode())
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("jep440")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("Unsupported type of record input"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.quarkus.ts.jdk17</groupId>
+    <groupId>io.quarkus.ts.jdk.specific</groupId>
     <artifactId>parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,6 @@
                             </excludes>
                             <systemPropertyVariables>
                                 <profile.id>${profile.id}</profile.id>
-                                <postgresql.13.image>docker.io/library/postgres:13.6</postgresql.13.image>
                                 <postgresql.latest.image>docker.io/library/postgres:15.4</postgresql.latest.image>
                             </systemPropertyVariables>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@
                             <systemPropertyVariables>
                                 <profile.id>${profile.id}</profile.id>
                                 <postgresql.13.image>docker.io/library/postgres:13.6</postgresql.13.image>
+                                <postgresql.latest.image>docker.io/library/postgres:15.4</postgresql.latest.image>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -271,6 +272,18 @@
                 <module>jdk17/jakarta-rest-panache</module>
                 <module>jdk17/graphql</module>
             </modules>
+        </profile>
+        <profile>
+            <id>JDK21</id>
+            <activation>
+                <jdk>21</jdk>
+            </activation>
+            <modules>
+                <module>jdk21/resteasy-reactive-jackson</module>
+            </modules>
+            <properties>
+                <maven.compiler.release>21</maven.compiler.release>
+            </properties>
         </profile>
         <profile>
             <id>native</id>


### PR DESCRIPTION
Hi, this PR adding showcase of some new features from JDK18-21. 

The CI only adding JDK21 to jvm runs, as there is not `ubi-quarkus-mandrel-builder-image` available for JDK21.

Adding of `-Dnet.bytebuddy.experimental=true` is because bytebuddy is transitive dependency of hibernate and probably latest Quarkus don't have updated hibernate version which support latest bytebuddy (maybe even bytebuddy don't have version which goes from experimental to supported as latest version was released before JDK21) 