### PR TITLE
Add JDK 21 preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -49,7 +49,7 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 17, 21-ea ]
+        java: [ 17, 21 ]
     steps:
       - uses: actions/checkout@v3
       - name: Reclaim Disk Space
@@ -73,7 +73,7 @@ jobs:
         run: |
           mvn -V -B -s .github/mvn-settings.xml verify -Dvalidate-format -DskipTests -DskipITs
       - name: Build with Maven
-        run: mvn -fae -V -B -s .github/mvn-settings.xml clean verify -Dnet.bytebuddy.experimental=true
+        run: mvn -fae -V -B -s .github/mvn-settings.xml clean verify
       - name: Zip Artifacts
         if: failure()
         run: |
@@ -89,13 +89,21 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 17 ]
-        image: [ "ubi-quarkus-mandrel-builder-image:23.0-java17" ]
-        profiles: [ "JDK17"]
+        java: [ 17, 21 ]
     steps:
       - uses: actions/checkout@v3
       - name: Reclaim Disk Space
         run: .github/ci-prerequisites.sh
+      - name: Set Profile and Mandrel Image
+        id: set-mandrel-image
+        run: |
+          if [[ ${{ matrix.java }} == 17 ]]; then
+            echo PROFILE=JDK17 >> $GITHUB_OUTPUT
+            echo MANDREL_IMAGE=ubi-quarkus-mandrel-builder-image:23.0-java17 >> $GITHUB_OUTPUT
+          else
+            echo PROFILE=JDK21 >> $GITHUB_OUTPUT
+            echo MANDREL_IMAGE=ubi-quarkus-mandrel-builder-image:23.1-java21 >> $GITHUB_OUTPUT
+          fi
       - name: Install JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
@@ -111,8 +119,8 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Test in Native mode
         run: |
-          mvn -fae -V -B -s .github/mvn-settings.xml -P ${{ matrix.profiles }} -fae clean verify -Dnative \
-          -Dquarkus.native.builder-image=quay.io/quarkus/${{ matrix.image }}
+          mvn -fae -V -B -s .github/mvn-settings.xml -P ${{ steps.set-mandrel-image.outputs.PROFILE }} clean verify -Dnative \
+          -Dquarkus.native.builder-image=quay.io/quarkus/${{ steps.set-mandrel-image.outputs.MANDREL_IMAGE }}
       - name: Zip Artifacts
         if: failure()
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quarkus Jdk specifics Test Suite
 
-[![Daily Build](https://github.com/quarkus-qe/quarkus-jdkspecifics/actions/workflows/daily.yaml/badge.svg)](https://github.com/quarkus-qe/quarkus-jdkspecifics/actions/workflows/daily.yaml)
+[![Daily Build](https://github.com/quarkus-qe/quarkus-jdkspecifics/actions/workflows/ci.yml/badge.svg)](https://github.com/quarkus-qe/quarkus-jdkspecifics/actions/workflows/daily.yaml)
 
 The goal of this TS is to cover the most interesting [JEPs](http://openjdk.java.net/jeps/1)  implemented since JDK 11
 

--- a/README.md
+++ b/README.md
@@ -59,3 +59,9 @@ Interesting preview:
 * [Pattern Matching for switch](https://openjdk.java.net/jeps/441)
 * [Sequenced Collections](https://openjdk.java.net/jeps/431)
 * [Code Snippets in Java API Documentation](https://openjdk.java.net/jeps/413)
+
+### Qute
+* [JEP 430: String Templates (Preview)](https://openjdk.java.net/jeps/430)
+* [JEP 445: Unnamed Classes and Instance Main Methods (Preview)](https://openjdk.java.net/jeps/445)
+* [Pattern Matching for switch](https://openjdk.java.net/jeps/441)
+

--- a/jdk21/qute/pom.xml
+++ b/jdk21/qute/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkus.ts.jdk.specific</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+    <artifactId>qute</artifactId>
+    <packaging>jar</packaging>
+    <name>Quarkus JDK21 TS: Preview and Qute</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-qute</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/jdk21/qute/src/main/java/io/quarkus/ts/jdk21/preview/PreviewResources.java
+++ b/jdk21/qute/src/main/java/io/quarkus/ts/jdk21/preview/PreviewResources.java
@@ -1,0 +1,111 @@
+package io.quarkus.ts.jdk21.preview;
+
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.ts.jdk21.preview.records.RecordPreviewShowcase;
+import io.quarkus.ts.jdk21.preview.records.UnnamedRecordQute;
+import io.quarkus.ts.jdk21.preview.records.WebTemplatePreview;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("preview")
+@ApplicationScoped
+public class PreviewResources {
+
+    public static final String HEADER = "Header name";
+    public static final String CUSTOM_TEXT = "This is a paragraph text. which will be under the header";
+
+    @GET
+    @Path("{name}")
+    public String getName(String name) {
+        return STR."Hello \{name}";
+    }
+
+    /**
+     * Showcase the templates use case in text block. This can be useful when working in texts using some structure
+     *
+     * @return Build response as html with status 200
+     */
+    @GET
+    @Path("template")
+    @Produces(MediaType.TEXT_HTML)
+    public Response getWebTemplate() {
+        return Response.ok(STR."""
+            <!DOCTYPE html>
+            <html>
+                <body>
+                    <h1>\{HEADER}</h1>
+                    <p>\{CUSTOM_TEXT}</p>
+                </body>
+            </html>""").status(200).build();
+    }
+
+    /**
+     * Same situation as {@link #getWebTemplate()} but with usage Qute
+     *
+     * @return The html template build by Qute
+     */
+    @GET
+    @Path("templateQute")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance getWebTemplateQute() {
+        return new WebTemplatePreview(HEADER, CUSTOM_TEXT);
+    }
+
+    /**
+     * Showcasing the multiple unnamed patterns (keyword _), String templates and enhanced switch with records.
+     * @param recordPreviewShowcase POST request containing values
+     * @return Response containing string with details of record attributes or unsupported string mention
+     */
+    @POST
+    @Produces(MediaType.TEXT_PLAIN)
+    @Path("unnamed/variables")
+    public Response unnamedPatterns(RecordPreviewShowcase recordPreviewShowcase) {
+        switch (recordPreviewShowcase) {
+            case RecordPreviewShowcase(String string1, _, _, String string4) -> {
+                return Response.ok(STR."""
+                This case matching only if the first and last attribute are strings.
+                At the same time we care only about these two values and it's possible to print them like:
+                Value 1 \{string1} and value 4 \{string4}""").status(200).build();
+            }
+            case RecordPreviewShowcase(_, String string, _, Integer integer) -> {
+                return Response.ok(STR."""
+                This case matching only if the second attribute is strings and last attribute is integer.
+                At the same time we care only about these two values and it's possible to print them like:
+                Value 2 \{string} and value 4 \{integer}""").status(200).build();
+            }
+            default -> {
+                return Response.ok("Unsupported type of record input").status(200).build();
+            }
+        }
+    }
+
+    /**
+     * Showcasing the multiple unnamed patterns (keyword _), String templates and enhanced switch with records.
+     * In this use case we don't care about data of record but just data types.
+     *
+     * @param unnamedRecordQute POST request containing values
+     * @return Returning Qute template of record with added data type of second attribute
+     */
+    @POST
+    @Produces(MediaType.TEXT_HTML)
+    @Path("unnamed/qute")
+    public TemplateInstance unnamedPatternsAndQute(UnnamedRecordQute unnamedRecordQute) {
+        switch (unnamedRecordQute) {
+            case UnnamedRecordQute(String _, String _) -> {
+                return unnamedRecordQute.data("dataType", "String");
+            }
+            case UnnamedRecordQute(String _, Integer _) -> {
+                return unnamedRecordQute.data("dataType", "Integer");
+            }
+            default -> {
+                throw new BadRequestException();
+            }
+        }
+    }
+}

--- a/jdk21/qute/src/main/java/io/quarkus/ts/jdk21/preview/records/RecordPreviewShowcase.java
+++ b/jdk21/qute/src/main/java/io/quarkus/ts/jdk21/preview/records/RecordPreviewShowcase.java
@@ -1,0 +1,4 @@
+package io.quarkus.ts.jdk21.preview.records;
+
+public record RecordPreviewShowcase(Object value1, Object value2, Object value3, Object value4) {
+}

--- a/jdk21/qute/src/main/java/io/quarkus/ts/jdk21/preview/records/UnnamedRecordQute.java
+++ b/jdk21/qute/src/main/java/io/quarkus/ts/jdk21/preview/records/UnnamedRecordQute.java
@@ -1,0 +1,14 @@
+package io.quarkus.ts.jdk21.preview.records;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+
+/**
+ * As this is only showcase value1 will be used for substitution
+ *
+ * @param value2 String value
+ * @param value3 Data which will be different type
+ */
+@CheckedTemplate(requireTypeSafeExpressions = false)
+public record UnnamedRecordQute(String value1, Object value2) implements TemplateInstance {
+}

--- a/jdk21/qute/src/main/java/io/quarkus/ts/jdk21/preview/records/WebTemplatePreview.java
+++ b/jdk21/qute/src/main/java/io/quarkus/ts/jdk21/preview/records/WebTemplatePreview.java
@@ -1,0 +1,6 @@
+package io.quarkus.ts.jdk21.preview.records;
+
+import io.quarkus.qute.TemplateInstance;
+
+public record WebTemplatePreview(String headerOne, String customText) implements TemplateInstance {
+}

--- a/jdk21/qute/src/main/resources/templates/UnnamedRecordQute.html
+++ b/jdk21/qute/src/main/resources/templates/UnnamedRecordQute.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <p>First value is {value1} and it's String.</p>
+        <p>Second value is {value2} and it's {dataType}</p>
+    </body>
+</html>

--- a/jdk21/qute/src/main/resources/templates/WebTemplatePreview.html
+++ b/jdk21/qute/src/main/resources/templates/WebTemplatePreview.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <h1>{headerOne}</h1>
+        <p>{customText}</p>
+    </body>
+</html>

--- a/jdk21/qute/src/test/java/io/quarkus/ts/jdk21/preview/RecordMatchingPreviewResourcesIT.java
+++ b/jdk21/qute/src/test/java/io/quarkus/ts/jdk21/preview/RecordMatchingPreviewResourcesIT.java
@@ -1,0 +1,136 @@
+package io.quarkus.ts.jdk21.preview;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import io.quarkus.ts.jdk21.preview.records.RecordPreviewShowcase;
+import io.quarkus.ts.jdk21.preview.records.UnnamedRecordQute;
+import io.vertx.core.json.JsonObject;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
+
+@QuarkusScenario
+public class RecordMatchingPreviewResourcesIT {
+    private static final String STRING_TO_TEST = "test String";
+    private static final int INTEGER_TO_TEST = 39;
+    @QuarkusApplication
+    static final RestService app = new RestService();
+
+    @Test
+    public void testRecordWithTwoStringsAndNullValues() {
+        given()
+                .body(JsonObject.mapFrom(new RecordPreviewShowcase(STRING_TO_TEST, null, null, STRING_TO_TEST)).encode())
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("preview/unnamed/variables")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(stringContainsInOrder("first and last attribute are strings",
+                        STR."Value 1 \{STRING_TO_TEST}" , STR."value 4 \{STRING_TO_TEST}"));
+    }
+
+    @Test
+    public void testRecordWithTwoStringsAndIntegerValues() {
+        given()
+                .body(JsonObject.mapFrom(new RecordPreviewShowcase(STRING_TO_TEST, INTEGER_TO_TEST, INTEGER_TO_TEST, STRING_TO_TEST)).encode())
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("preview/unnamed/variables")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(stringContainsInOrder("first and last attribute are strings",
+                        STR."Value 1 \{STRING_TO_TEST}" , STR."value 4 \{STRING_TO_TEST}"));
+    }
+
+    @Test
+    public void testRecordWithStringIntegerAndNullValues() {
+        given()
+                .body(JsonObject.mapFrom(new RecordPreviewShowcase(null, STRING_TO_TEST, null, INTEGER_TO_TEST)).encode())
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("preview/unnamed/variables")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(stringContainsInOrder("second attribute is strings and last attribute is integer",
+                        STR."Value 2 \{STRING_TO_TEST}" , STR."value 4 \{INTEGER_TO_TEST}"));
+    }
+
+    @Test
+    public void testRecordWithTwoStringsAndIntegerValuesNegative() {
+        given()
+                .body(JsonObject
+                        .mapFrom(new RecordPreviewShowcase(INTEGER_TO_TEST, STRING_TO_TEST, INTEGER_TO_TEST, STRING_TO_TEST))
+                        .encode())
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("preview/unnamed/variables")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("Unsupported type of record input"));
+    }
+
+    @Test
+    public void testRecordWithTwoStringsAndNullValuesNegative() {
+        given()
+                .body(JsonObject.mapFrom(new RecordPreviewShowcase(null, STRING_TO_TEST, null, STRING_TO_TEST)).encode())
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("preview/unnamed/variables")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(containsString("Unsupported type of record input"));
+    }
+
+    @Test
+    public void testQuteRecordWithTwoStrings() {
+        given()
+                .body(STR."{\"value1\":\"\{STRING_TO_TEST}\",\"value2\":\"\{STRING_TO_TEST}\"}")
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("preview/unnamed/qute")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(stringContainsInOrder(STR."<p>First value is \{STRING_TO_TEST} and it's String.</p>",
+                        STR."<p>Second value is \{STRING_TO_TEST} and it's String</p>"));
+    }
+
+    @Test
+    public void testQuteRecordWithStringAndInteger() {
+        given()
+                .body(STR."{\"value1\":\"\{STRING_TO_TEST}\",\"value2\":\{INTEGER_TO_TEST}}")
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("preview/unnamed/qute")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(stringContainsInOrder(STR."<p>First value is \{STRING_TO_TEST} and it's String.</p>",
+                        STR."<p>Second value is \{INTEGER_TO_TEST} and it's Integer</p>"));
+    }
+
+    @Test
+    public void testQuteRecordWithIntegerAndString() {
+        given()
+                .body(STR."{\"value1\":\{INTEGER_TO_TEST},\"value2\":\{STRING_TO_TEST}}")
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("preview/unnamed/qute")
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+
+    @Test
+    public void testQuteRecordWithStringAndNull() {
+        given()
+                .body(STR."{\"value1\":\"\{STRING_TO_TEST}\",\"value2\":\{null}}")
+                .header("Content-Type", MediaType.APPLICATION_JSON)
+                .when()
+                .post("preview/unnamed/qute")
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+}

--- a/jdk21/qute/src/test/java/io/quarkus/ts/jdk21/preview/SimplePreviewResourcesIT.java
+++ b/jdk21/qute/src/test/java/io/quarkus/ts/jdk21/preview/SimplePreviewResourcesIT.java
@@ -1,0 +1,49 @@
+package io.quarkus.ts.jdk21.preview;
+
+import io.quarkus.test.bootstrap.RestService;
+import io.quarkus.test.scenarios.QuarkusScenario;
+import io.quarkus.test.services.QuarkusApplication;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import static io.quarkus.ts.jdk21.preview.PreviewResources.CUSTOM_TEXT;
+import static io.quarkus.ts.jdk21.preview.PreviewResources.HEADER;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
+
+@QuarkusScenario
+public class SimplePreviewResourcesIT {
+
+    @QuarkusApplication
+    static final RestService app = new RestService();
+
+    @Test
+    public void testStringTemplateWithName() {
+        String name = "Quarkus";
+        app.given()
+                .get(STR."/preview/\{name}")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(is(STR."Hello \{name}"));
+    }
+
+    @Test
+    public void testStringWebpageTemplate() {
+        app.given()
+                .get("/preview/template")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(stringContainsInOrder(STR."<h1>\{HEADER}</h1>"), containsString(STR."<p>\{CUSTOM_TEXT}</p>"));
+    }
+
+    @Test
+    public void testStringWebpageTemplateQute() {
+        app.given()
+                .get("/preview/templateQute")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body(stringContainsInOrder(STR."<h1>\{HEADER}</h1>"), containsString(STR."<p>\{CUSTOM_TEXT}</p>"));
+    }
+
+}

--- a/jdk21/qute/src/test/resources/test.properties
+++ b/jdk21/qute/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+ts.global.ts.enable-java-preview=true

--- a/jdk21/resteasy-reactive-jackson/pom.xml
+++ b/jdk21/resteasy-reactive-jackson/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>resteasy-reactive-jackson</artifactId>
     <packaging>jar</packaging>
-    <name>Quarkus JDK21 TS: test</name>
+    <name>Quarkus JDK21 TS: resteasy-reactive-jackson</name>
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <exclude.operator.openshift.tests>**/Operator*OpenShift*IT.java</exclude.operator.openshift.tests>
         <exclude.quarkus.cli.tests>**/QuarkusCli*IT.java</exclude.quarkus.cli.tests>
         <exclude.quarkus.devmode.tests>no</exclude.quarkus.devmode.tests>
+        <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.0-java17</quarkus.native.builder-image>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -232,6 +233,8 @@
                     <failsOnError>true</failsOnError>
                     <linkXRef>true</linkXRef>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <!-- exclude preview as latest checkstyle 3.3.0 not support unnamed patterns abd variables -->
+                    <excludes>**/preview/**</excludes>
                 </configuration>
                 <executions>
                     <execution>
@@ -279,9 +282,11 @@
             </activation>
             <modules>
                 <module>jdk21/resteasy-reactive-jackson</module>
+                <module>jdk21/qute</module>
             </modules>
             <properties>
                 <maven.compiler.release>21</maven.compiler.release>
+                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.1-java21</quarkus.native.builder-image>
             </properties>
         </profile>
         <profile>
@@ -316,8 +321,8 @@
                 <quarkus.package.type>native</quarkus.package.type>
                 <quarkus.native.container-build>true</quarkus.native.container-build>
                 <quarkus.native.native-image-xmx>4g</quarkus.native.native-image-xmx>
-                <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.0-java17</quarkus.native.builder-image>
                 <exclude.quarkus.devmode.tests>**/*DevMode*IT.java</exclude.quarkus.devmode.tests>
+                <quarkus.native.additional-build-args>-J--enable-preview</quarkus.native.additional-build-args>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
-        <quarkus.qe.framework.version>1.3.0.Beta27</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.3.0.Beta29</quarkus.qe.framework.version>
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.6.2</impsort-maven-plugin.version>
         <xml-format-maven-plugin.version>3.2.2</xml-format-maven-plugin.version>


### PR DESCRIPTION
Adding showcase of some previews and compere some of them with Qute + as was requested by @michalvavrik in #99 using Qute record with some preview to try add some cover to them.

Using two different mandrel for mainly base on JDK version.

Minor changes is bump framework to new version which support enable preview for jars. Updating name of JDK 21 name and update README link to daily build badge.