### PR TITLE
Update framework to 1.3.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
-        <quarkus.qe.framework.version>1.4.0.Beta1</quarkus.qe.framework.version>
+        <quarkus.qe.framework.version>1.3.0.Final</quarkus.qe.framework.version>
         <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.6.2</impsort-maven-plugin.version>
         <xml-format-maven-plugin.version>3.3.1</xml-format-maven-plugin.version>


### PR DESCRIPTION
Update framework to 1.3.0.Final

1.3.0.Final was released in https://github.com/quarkus-qe/quarkus-test-framework/pull/982

Let's use .Final version, we do not need special features from Beta releases.