### PR TITLE
Pom file cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,15 +255,6 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>confluent</id>
-            <url>https://packages.confluent.io/maven/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
     <profiles>
         <profile>
             <id>JDK17</id>

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
                 <version>${maven-checkstyle-plugin.version}</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
-                    <encoding>UTF-8</encoding>
+                    <inputEncoding>UTF-8</inputEncoding>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                     <linkXRef>true</linkXRef>


### PR DESCRIPTION
Pom file cleanup

**Fix checkstyle configuration parameter name**

Fixes [WARNING] Parameter 'encoding' is unknown for plugin 'maven-checkstyle-plugin:3.3.1:check (validate)'

**Remove confluent repo definition to speed up build**

Confluent repo is legacy bit now