### PR TITLE
Switch to quarkus-rest artifacts instead of quarkus-resteasy-reactive

### DIFF
--- a/jdk21/qute/pom.xml
+++ b/jdk21/qute/pom.xml
@@ -13,11 +13,11 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-qute</artifactId>
+            <artifactId>quarkus-rest-qute</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/jdk21/resteasy-reactive-jackson/pom.xml
+++ b/jdk21/resteasy-reactive-jackson/pom.xml
@@ -17,7 +17,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
+            <artifactId>quarkus-rest-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Switch to quarkus-rest artifacts instead of quarkus-resteasy-reactive

Removes warnings like [WARNING] The artifact io.quarkus:quarkus-resteasy-reactive-jackson:jar:999-SNAPSHOT has been relocated to io.quarkus:quarkus-rest-jackson:jar:999-SNAPSHOT: Update the artifactId in your project build file. Refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.9 for more information.