### PR TITLE
Set quarkus-test-preparer plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
             <plugin>
                 <groupId>io.quarkus.qe</groupId>
                 <artifactId>quarkus-test-preparer</artifactId>
+                <version>${quarkus.qe.framework.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Set quarkus-test-preparer plugin version

Eliminates warnings about missing version
```
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.quarkus.ts.jdk.specific:resteasy-reactive-jackson:jar:1.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for io.quarkus.qe:quarkus-test-preparer is missing. @ io.quarkus.ts.jdk.specific:parent:1.0.0-SNAPSHOT, /Users/rsvoboda/git/quarkus-jdkspecifics/pom.xml, line 103, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.quarkus.ts.jdk.specific:qute:jar:1.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for io.quarkus.qe:quarkus-test-preparer is missing. @ io.quarkus.ts.jdk.specific:parent:1.0.0-SNAPSHOT, /Users/rsvoboda/git/quarkus-jdkspecifics/pom.xml, line 103, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.quarkus.ts.jdk.specific:parent:pom:1.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for io.quarkus.qe:quarkus-test-preparer is missing. @ line 103, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
[INFO] Quarkus JDK Specifics TS: Parent                                   [pom]
[INFO] Quarkus JDK21 TS: resteasy-reactive-jackson                        [jar]
[INFO] Quarkus JDK21 TS: Preview and Qute                                 [jar]
...
```