### PR TITLE
Bump formatter-maven-plugin from 2.23.0 to 2.26.0

### DIFF
--- a/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/characters/CharacterResource.java
+++ b/jdk21/resteasy-reactive-jackson/src/main/java/io/quarkus/ts/jdk21/characters/CharacterResource.java
@@ -30,14 +30,15 @@ public class CharacterResource {
      * <p>
      * Prior to JDK 21 it would be
      * {@snippet :
-     *     Character entity = entityManager.find(Character.class, id);
-     *     if(entity == null) {
-     *          // do something
-     *     }
-     *     switch (entity) {
-     *          // switch cases
-     *     }
+     * Character entity = entityManager.find(Character.class, id);
+     * if (entity == null) {
+     *     // do something
      * }
+     * switch (entity) {
+     *     // switch cases
+     * }
+     * }
+     *
      * @param id Id of hero
      * @return Error or type of character
      */
@@ -77,7 +78,8 @@ public class CharacterResource {
         }
         switch (rank) {
             case Hero.Rank r when r == Hero.Rank.S -> {
-                return Response.ok("S rank is highest rank which can hero achieve. Only few have achieve this.").status(200).build();
+                return Response.ok("S rank is highest rank which can hero achieve. Only few have achieve this.").status(200)
+                        .build();
             }
             case Hero.Rank r when r == Hero.Rank.A -> {
                 return Response.ok("A rank is for experience heroes which had done good work.").status(200).build();

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
         <quarkus.qe.framework.version>1.6.0</quarkus.qe.framework.version>
-        <formatter-maven-plugin.version>2.23.0</formatter-maven-plugin.version>
+        <formatter-maven-plugin.version>2.26.0</formatter-maven-plugin.version>
         <impsort-maven-plugin.version>1.6.2</impsort-maven-plugin.version>
         <xml-format-maven-plugin.version>4.1.0</xml-format-maven-plugin.version>
         <checkstyle.version>10.21.4</checkstyle.version>


### PR DESCRIPTION
Bump formatter-maven-plugin from 2.23.0 to 2.26.0

https://github.com/revelc/formatter-maven-plugin/issues/907 is fixed now