### PR TITLE
Drop ubi-quarkus-mandrel-builder-image:jdk-21 usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 17, 21 ]
+        java: [ 17 ]
     steps:
       - uses: actions/checkout@v3
       - name: Reclaim Disk Space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,10 @@ jobs:
         run: |
           if [[ ${{ matrix.java }} == 17 ]]; then
             echo PROFILE=JDK17 >> $GITHUB_OUTPUT
-            echo MANDREL_IMAGE=ubi-quarkus-mandrel-builder-image:jdk-21 >> $GITHUB_OUTPUT
+            echo MANDREL_IMAGE=ubi-quarkus-mandrel-builder-image:jdk-25 >> $GITHUB_OUTPUT
           else
             echo PROFILE=JDK21 >> $GITHUB_OUTPUT
-            echo MANDREL_IMAGE=ubi-quarkus-mandrel-builder-image:jdk-21 >> $GITHUB_OUTPUT
+            echo MANDREL_IMAGE=ubi-quarkus-mandrel-builder-image:jdk-25 >> $GITHUB_OUTPUT
           fi
       - name: Install JDK ${{ matrix.java }}
         uses: actions/setup-java@v3


### PR DESCRIPTION
Drop ubi-quarkus-mandrel-builder-image:jdk-21 usage

ubi-quarkus-mandrel-builder-image:jdk-25 is the way to go, one supported Mandrel version