### PR TITLE
Switch main branch from Quarkus 3.x to 3.39 as 3.x was deleted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus main
         run: |
-          git clone -b 3.39 https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dscalpel.enabled=false
+          git clone https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dscalpel.enabled=false
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build Quarkus main
         run: |
-          git clone -b 3.x https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dscalpel.enabled=false
+          git clone -b 3.39 https://github.com/quarkusio/quarkus.git && cd quarkus && ./mvnw -B --no-transfer-progress -s .github/mvn-settings.xml clean install -Dquickly -Prelocations -Dscalpel.enabled=false
       - name: Tar Maven Repo
         shell: bash
         run: tar -I 'pigz -9' -cf maven-repo.tgz -C ~ .m2/repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17 ]
+        java: [ 21 ]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/cache@v6
@@ -49,7 +49,7 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 17, 21 ]
+        java: [ 21 ]
     steps:
       - uses: actions/checkout@v7
       - name: Reclaim Disk Space
@@ -89,7 +89,7 @@ jobs:
     needs: build-dependencies
     strategy:
       matrix:
-        java: [ 17 ]
+        java: [ 21 ]
     steps:
       - uses: actions/checkout@v7
       - name: Reclaim Disk Space

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <failsafe-plugin.version>3.5.6</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.39.999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
         <quarkus.qe.framework.version>999-SNAPSHOT</quarkus.qe.framework.version>
         <formatter-maven-plugin.version>2.29.0</formatter-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
                             </excludes>
                             <systemPropertyVariables>
                                 <profile.id>${profile.id}</profile.id>
-                                <postgresql.latest.image>docker.io/library/postgres:15.4</postgresql.latest.image>
+                                <postgresql.latest.image>docker.io/library/postgres:16</postgresql.latest.image>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>Quarkus JDK Specifics TS: Parent</name>
     <properties>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <failsafe-plugin.version>3.5.6</failsafe-plugin.version>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>3.999-SNAPSHOT</quarkus.platform.version>
+        <quarkus.platform.version>3.39.999-SNAPSHOT</quarkus.platform.version>
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
         <quarkus.qe.framework.version>999-SNAPSHOT</quarkus.qe.framework.version>
         <formatter-maven-plugin.version>2.29.0</formatter-maven-plugin.version>


### PR DESCRIPTION
Updating from 3.x to 3.39 branch before switching to main again. Same thing was updated for 3.x effort https://github.com/quarkus-qe/quarkus-jdkspecifics/pull/223